### PR TITLE
docs: document project vision and workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Pixie Personal Photo Agent
+
+## Overview
+Pixie is a standalone assistant that helps people organise their personal photo libraries. It analyses the existing folder structure, understands a user's stated preferences, and plans safe file moves so every photo ends up where it belongs. The long-term goal is to give users confidence that Pixie can take a pile of unsorted memories and transform it into a curated collection.
+
+## Core Use Cases
+- **Inbox triage** – interpret natural-language context supplied with photos placed in a "To sort" folder and recommend the best destination folders.
+- **Preference-aware organisation** – respect the user's conventions for naming, hierarchy depth, and people or event tags when planning folder creation and file moves.
+- **Guided operation** – offer dry-run previews, undo logs, and conversational prompts so users stay in control while Pixie performs the heavy lifting.
+
+## Planned Capabilities
+- Inspect existing libraries to understand current folder patterns and important metadata.
+- Create new folders or rename existing ones to match expressed preferences.
+- Move, copy, or skip photos with full audit logging and the ability to undo changes.
+- Accept natural-language instructions that clarify what the latest batch of photos represents (e.g., people, places, dates).
+- Learn from prior decisions to refine future recommendations.
+
+## Roadmap & Further Reading
+Pixie's product vision and detailed workflows are documented in the `docs/` directory.
+
+- [Vision](docs/vision.md)
+- ["To sort" workflow and preference handling](docs/to-sort-workflow.md)
+- [Folder organisation system design](docs/system-design.md)
+
+Contributors should review these documents before proposing new features so that design and implementation decisions stay aligned with Pixie's mission.

--- a/docs/system-design.md
+++ b/docs/system-design.md
@@ -1,0 +1,35 @@
+# Folder Organisation System Design
+
+This document outlines the planned components that will allow Pixie to inspect libraries, plan folder structures, and execute moves safely.
+
+## Architectural Overview
+Pixie is composed of three primary subsystems:
+
+1. **Filesystem scanner** – Reads the source inbox and target library, collecting metadata such as folder hierarchy, file counts, timestamps, and EXIF attributes. It should support dry runs and run-time filters to limit scope.
+2. **Decision engine** – Combines user preferences, historical approvals, and current batch context to decide where each file belongs. The engine produces a ranked list of proposed destinations plus rationales.
+3. **Move executor** – Applies the approved plan, handling folder creation, renames, moves, and rollback logging. It must gracefully handle partial failures and provide undo information.
+
+## Key Data Flows
+- **Input**: Paths to the "To sort" inbox and the destination library, optional natural-language prompts, stored preference files, and audit history.
+- **Processing**: The scanner maps the current state, the decision engine builds a plan, and the executor performs operations once the user approves.
+- **Output**: Updated folder structure, audit CSVs, and a summary report for the user.
+
+## Operating Assumptions
+- Pixie runs as a standalone CLI application with permissions to read and write within the configured directories.
+- The user provides clear natural-language context when necessary but Pixie should default to safe holding areas when unsure.
+- Audit logs are stored in the repository root (or configurable path) and can be replayed to undo actions.
+
+## Error Handling
+- **Pre-flight checks**: Validate source and target paths, ensure sufficient disk space, and confirm write permissions before planning moves.
+- **Transactional moves**: Use temporary staging and renaming strategies to minimise the chance of partially moved files.
+- **Recovery**: Provide a command (`--undo <audit_file>`) that replays the audit log to revert changes when possible.
+
+## Extensibility Considerations
+- **Plugin architecture**: Allow new metadata extractors (e.g., face recognition, object detection) to feed the decision engine without rewriting the core.
+- **Cloud and hybrid storage**: Design abstractions so future integrations with cloud providers can reuse the same planning logic.
+- **Automation hooks**: Expose APIs or scheduled tasks so Pixie can process new photos automatically once trust is established.
+
+## Next Steps
+- Define the schema for preference storage and auditing.
+- Prototype the decision engine using a rules-based approach before layering ML-driven suggestions.
+- Create sample libraries and automated tests to validate moves without touching personal data.

--- a/docs/to-sort-workflow.md
+++ b/docs/to-sort-workflow.md
@@ -1,0 +1,31 @@
+# "To Sort" Workflow and Preference Handling
+
+This document defines how Pixie should process photos staged in the user's "To sort" folder and how preference data influences the proposed organisation plan.
+
+## Workflow Overview
+1. **User staging** – The user drops new or backlog photos into the "To sort" folder and optionally writes a short natural-language note describing the batch (e.g., "Emma's birthday, March 2024, park picnic").
+2. **Context gathering** – Pixie scans the target library to understand existing folder patterns, people or event naming conventions, and date formats. It also checks stored preference files or prior user confirmations.
+3. **Interpretation** – Pixie parses the natural-language note plus embedded metadata (EXIF timestamps, geolocation, faces) to produce a structured intent: who is involved, what event occurred, when and where it happened, and any special handling instructions.
+4. **Planning** – Based on the intent and the observed library structure, Pixie proposes folder operations: create new folders, reuse existing ones, or adjust naming to stay consistent. It prepares an audit table that describes each planned move.
+5. **Review loop** – Pixie presents the plan for confirmation. The user can accept, decline, or refine the instructions conversationally.
+6. **Execution** – When approved, Pixie performs moves (or copies) and records the outcome in an audit CSV for undo purposes.
+
+## Preference Sources
+- **Configuration file** – A structured file (e.g., `preferences.json`) stores explicit choices such as default date formats, preferred folder depth, and whether to group by people or events.
+- **Learned behaviour** – Pixie updates heuristics based on previous user approvals or corrections, gradually learning custom folder names and ordering.
+- **Inline instructions** – Natural-language commands supplied with a batch take precedence for that run (e.g., "Use yyyy-mm event naming" or "Keep duplicates").
+
+## Edge Cases and Safeguards
+- **Conflicting instructions** – When inline instructions clash with stored preferences, Pixie should request clarification before executing moves.
+- **Missing metadata** – If crucial data such as dates or locations is absent, Pixie should either prompt for details or default to a safe holding folder that flags the issue.
+- **Permission issues** – The agent must verify write access before planning moves and surface actionable errors when access is denied.
+- **Large batches** – For thousands of photos, Pixie should chunk operations and ensure the audit log remains readable.
+
+## Outputs
+- **Audit CSV** – Captures proposed and completed actions, including source path, destination path, decision reason, and status.
+- **Summary report** – Highlights newly created folders, skipped items, and follow-up questions for the user.
+
+## Future Considerations
+- Automate preference onboarding by interviewing the user the first time they run Pixie.
+- Support collaborative households by letting multiple profiles share a library with personalised preferences.
+- Integrate confidence scores so the user can quickly review uncertain decisions before approval.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,23 @@
+# Pixie Vision
+
+Pixie is a standalone agent that gives people a trustworthy companion for organising their personal photo collections. The project aspires to combine deep awareness of a user's existing folder structure with conversational guidance so that tidying up photos feels collaborative rather than tedious.
+
+## Mission
+- Deliver an assistant that can sort large backlogs of photos without compromising the user's preferred organisation style.
+- Provide clear previews and undo paths so every automated action feels reversible and safe.
+- Keep the experience self-contained, running locally when possible so users can work with private collections without relying on external services.
+
+## Guiding Principles
+1. **Context first** – Pixie always inspects the current library before acting so it can mimic the user's conventions.
+2. **Explainability** – Every planned move comes with a reason and appears in an audit log for review.
+3. **User-in-the-loop** – Pixie accepts natural-language direction and confirmations, blending automation with conversational control.
+4. **Resilience** – Operations should be idempotent, guard against partial moves, and offer straightforward recovery steps.
+
+## Success Indicators
+- Users routinely rely on the "To sort" inbox as a staging area and trust Pixie to make the right choices.
+- Library structures remain coherent after repeated runs, demonstrating that Pixie adapts to evolving preferences.
+- Contributors can extend Pixie's capabilities without re-learning the system because the design documents and roadmap stay current.
+
+## Related Documents
+- ["To sort" workflow and preference handling](to-sort-workflow.md)
+- [Folder organisation system design](system-design.md)


### PR DESCRIPTION
## Summary
- add a README that introduces Pixie and links to deeper planning docs
- document the long-term product vision, inbox workflow, and system design in the docs directory

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8f33da9e8832097461f5e93e16b8b