### PR TITLE
fix: add landing page for prototypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,8 @@ Pixie's product vision and detailed workflows are documented in the `docs/` dire
 - ["To sort" workflow and preference handling](docs/to-sort-workflow.md)
 - [Folder organisation system design](docs/system-design.md)
 
+## Experiments
+- **Playground launcher** – Start a static server from the repo root (e.g., `python -m http.server 8000`) and open `http://localhost:8000/` to get a landing page that links to available prototypes.
+- **Starlight Picker prototype** – A Phaser-based proof of concept described in [docs/specifications/initial-concept.md](docs/specifications/initial-concept.md) and playable at `games/starlight-picker/index.html` when served locally with a static web server.
+
 Contributors should review these documents before proposing new features so that design and implementation decisions stay aligned with Pixie's mission.

--- a/docs/specifications/initial-concept.md
+++ b/docs/specifications/initial-concept.md
@@ -1,0 +1,27 @@
+# Starlight Picker – Initial Concept
+
+Starlight Picker is a light, arcade-style prototype where players scoop up fallen starlight while drifting through a calm night sky. The goal is to quickly showcase the feel of the loop without needing art assets or complex UI.
+
+## Core Loop
+- Move your ship to collect drifting starlight shards.
+- Avoid space debris that knocks energy off your hull.
+- Survive the short session and rack up the highest score before your energy runs out.
+
+## Controls & Rules
+- **Movement:** Arrow keys to glide across the screen; movement is limited to the visible playfield.
+- **Scoring:** Each shard adds points; consecutive pickups can be tuned later for streak bonuses.
+- **Damage:** Colliding with debris removes energy/hearts. When energy is gone, the run ends.
+- **Replayability:** A restart key should immediately reset the round without reloading the page.
+
+## MVP Requirements
+- Phaser-based single scene with a playable ship, collectible shards, and simple debris obstacles.
+- Minimal HUD showing score, remaining energy/hearts, and a short description of controls.
+- Procedural spawning for shards and debris to keep runs varied.
+- Friendly difficulty curve suitable for a proof of concept; winning or losing should be clear.
+
+## Visual Language
+- Use solid-color primitives (triangles, circles, stars) so the build stays asset-free.
+- Soft space palette (midnight background, warm highlights for shards, cool tones for debris).
+- Subtle particle or glint effects can be added later; start with clean silhouettes.
+
+This concept is intentionally lean so you can validate gameplay flow and integration with future AI-generated content.

--- a/games/starlight-picker/README.md
+++ b/games/starlight-picker/README.md
@@ -1,0 +1,12 @@
+# Starlight Picker Prototype
+
+A minimal Phaser-based proof of concept inspired by `docs/specifications/initial-concept.md`. Fly a small ship, pick up golden starlight shards, and dodge drifting debris. Restart instantly with **R**.
+
+## How to run locally
+1. From the repository root, start a simple web server:
+   - Python: `python -m http.server 8000`
+   - Or `npx http-server` if you prefer Node-based tooling.
+2. Open `http://localhost:8000/games/starlight-picker/` in your browser.
+3. Use the arrow keys to move, collect starlight for points, dodge debris, and press **R** after a run to restart.
+
+No build step is required because Phaser is loaded from a CDN and all visuals use generated shapes.

--- a/games/starlight-picker/index.html
+++ b/games/starlight-picker/index.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Starlight Picker – Prototype</title>
+    <script src="https://cdn.jsdelivr.net/npm/phaser@3.70.0/dist/phaser.min.js"></script>
+    <style>
+      body {
+        margin: 0;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: radial-gradient(circle at 20% 20%, #1b1f3b, #050711 60%);
+        color: #e6ecff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 100vh;
+      }
+
+      #wrapper {
+        text-align: center;
+        width: 900px;
+      }
+
+      #game-container {
+        margin: 0 auto;
+        box-shadow: 0 12px 35px rgba(5, 7, 17, 0.6);
+        border: 1px solid #2c335d;
+      }
+
+      p {
+        color: #a4b0d6;
+        margin-top: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="wrapper">
+      <h1>Starlight Picker</h1>
+      <div id="game-container"></div>
+      <p>
+        Use the arrow keys to glide, collect golden starlight for points, dodge blue debris, and press
+        <strong>R</strong> to restart after a run.
+      </p>
+    </div>
+
+    <script>
+      class StarlightScene extends Phaser.Scene {
+        constructor() {
+          super('StarlightScene');
+          this.cursors = null;
+          this.player = null;
+          this.starGroup = null;
+          this.debrisGroup = null;
+          this.scoreText = null;
+          this.statusText = null;
+          this.score = 0;
+          this.hearts = 3;
+          this.gameActive = true;
+          this.spawnTimers = [];
+        }
+
+        preload() {
+          this.createTextures();
+        }
+
+        create() {
+          this.cursors = this.input.keyboard.createCursorKeys();
+          this.input.keyboard.on('keydown-R', () => this.resetRun());
+
+          this.createBackgroundStars();
+          this.createPlayer();
+          this.createGroups();
+          this.createUI();
+          this.startSpawners();
+        }
+
+        update() {
+          if (!this.gameActive) return;
+
+          const speed = 260;
+          this.player.setVelocity(0, 0);
+
+          if (this.cursors.left.isDown) {
+            this.player.setVelocityX(-speed);
+          } else if (this.cursors.right.isDown) {
+            this.player.setVelocityX(speed);
+          }
+
+          if (this.cursors.up.isDown) {
+            this.player.setVelocityY(-speed);
+          } else if (this.cursors.down.isDown) {
+            this.player.setVelocityY(speed);
+          }
+
+          Phaser.Math.Clamp(this.player.x, 24, this.scale.width - 24);
+          Phaser.Math.Clamp(this.player.y, 24, this.scale.height - 24);
+        }
+
+        createTextures() {
+          const star = this.make.graphics({ x: 0, y: 0, add: false });
+          star.fillStyle(0xffd166, 1);
+          star.fillCircle(12, 12, 10);
+          star.generateTexture('starlight', 24, 24);
+
+          const debris = this.make.graphics({ x: 0, y: 0, add: false });
+          debris.fillStyle(0x4dd0e1, 1);
+          debris.fillRoundedRect(0, 0, 22, 22, 6);
+          debris.generateTexture('debris', 22, 22);
+
+          const ship = this.make.graphics({ x: 0, y: 0, add: false });
+          ship.fillStyle(0xf28482, 1);
+          ship.fillTriangle(14, 0, 28, 28, 0, 28);
+          ship.fillStyle(0xfff5e1, 1);
+          ship.fillTriangle(14, 4, 22, 26, 6, 26);
+          ship.generateTexture('ship', 28, 28);
+        }
+
+        createBackgroundStars() {
+          const particles = this.add.particles(0, 0, 'starlight', {
+            x: { min: 0, max: this.scale.width },
+            y: { min: 0, max: this.scale.height },
+            lifespan: { min: 4000, max: 8000 },
+            speedY: { min: 5, max: 20 },
+            speedX: { min: -5, max: 5 },
+            scale: { start: 0.25, end: 0 },
+            alpha: { start: 0.6, end: 0 },
+            quantity: 2,
+            frequency: 300,
+            blendMode: 'ADD'
+          });
+          particles.setDepth(-1);
+        }
+
+        createPlayer() {
+          this.player = this.physics.add.sprite(this.scale.width / 2, this.scale.height - 70, 'ship');
+          this.player.setCollideWorldBounds(true);
+          this.player.body.setSize(18, 24).setOffset(5, 2);
+        }
+
+        createGroups() {
+          this.starGroup = this.physics.add.group();
+          this.debrisGroup = this.physics.add.group();
+
+          this.physics.add.overlap(this.player, this.starGroup, (_player, star) => {
+            star.destroy();
+            this.adjustScore(10);
+          });
+
+          this.physics.add.overlap(this.player, this.debrisGroup, (_player, rock) => {
+            if (!this.gameActive) return;
+            rock.destroy();
+            this.applyDamage();
+          });
+        }
+
+        createUI() {
+          this.scoreText = this.add.text(12, 12, '', {
+            fontSize: '18px',
+            fontFamily: 'monospace',
+            color: '#f8f9fb'
+          });
+
+          this.statusText = this.add.text(this.scale.width / 2, this.scale.height / 2, '', {
+            fontSize: '28px',
+            fontFamily: 'monospace',
+            color: '#f8f9fb'
+          }).setOrigin(0.5);
+
+          this.updateHUD();
+        }
+
+        startSpawners() {
+          this.clearSpawners();
+          this.spawnTimers.push(
+            this.time.addEvent({ delay: 750, loop: true, callback: () => this.spawnStar() })
+          );
+          this.spawnTimers.push(
+            this.time.addEvent({ delay: 1300, loop: true, callback: () => this.spawnDebris() })
+          );
+        }
+
+        clearSpawners() {
+          this.spawnTimers.forEach((timer) => timer.destroy());
+          this.spawnTimers = [];
+        }
+
+        spawnStar() {
+          if (!this.gameActive) return;
+          const x = Phaser.Math.Between(30, this.scale.width - 30);
+          const star = this.starGroup.create(x, -30, 'starlight');
+          star.setVelocityY(Phaser.Math.Between(140, 220));
+        }
+
+        spawnDebris() {
+          if (!this.gameActive) return;
+          const x = Phaser.Math.Between(30, this.scale.width - 30);
+          const rock = this.debrisGroup.create(x, -30, 'debris');
+          rock.setVelocityY(Phaser.Math.Between(110, 180));
+          rock.setAngularVelocity(Phaser.Math.Between(-90, 90));
+        }
+
+        adjustScore(amount) {
+          this.score += amount;
+          this.updateHUD();
+        }
+
+        applyDamage() {
+          if (!this.gameActive) return;
+
+          this.hearts -= 1;
+          this.player.setTintFill(0xffd166);
+          this.time.delayedCall(150, () => this.player.clearTint());
+          this.updateHUD();
+
+          if (this.hearts <= 0) {
+            this.endRun('Hull integrity lost');
+          }
+        }
+
+        updateHUD() {
+          this.scoreText.setText(`Score: ${this.score}  |  Hearts: ${this.hearts}`);
+        }
+
+        endRun(message) {
+          this.gameActive = false;
+          this.clearSpawners();
+          this.statusText.setText(`${message}\nPress R to fly again`);
+
+          this.starGroup.setVelocityY(0);
+          this.debrisGroup.setVelocityY(0);
+          this.player.setVelocity(0, 0);
+        }
+
+        resetRun() {
+          this.gameActive = true;
+          this.score = 0;
+          this.hearts = 3;
+          this.statusText.setText('');
+          this.starGroup.clear(true, true);
+          this.debrisGroup.clear(true, true);
+          this.player.setPosition(this.scale.width / 2, this.scale.height - 70);
+          this.updateHUD();
+          this.startSpawners();
+        }
+      }
+
+      const config = {
+        type: Phaser.AUTO,
+        parent: 'game-container',
+        width: 800,
+        height: 600,
+        backgroundColor: '#060b1a',
+        physics: {
+          default: 'arcade',
+          arcade: { gravity: { y: 0 }, debug: false }
+        },
+        scene: [StarlightScene]
+      };
+
+      new Phaser.Game(config);
+    </script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Pixie Playground</title>
+    <style>
+      body {
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: radial-gradient(circle at 25% 20%, #20263d, #0d101b 60%);
+        color: #e6ecff;
+        min-height: 100vh;
+        margin: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .card {
+        background: rgba(18, 23, 41, 0.9);
+        border: 1px solid #2c335d;
+        border-radius: 12px;
+        padding: 24px;
+        box-shadow: 0 12px 35px rgba(5, 7, 17, 0.55);
+        max-width: 480px;
+        text-align: center;
+      }
+
+      h1 {
+        margin-top: 0;
+      }
+
+      p {
+        color: #a4b0d6;
+        line-height: 1.5;
+      }
+
+      a.button {
+        display: inline-block;
+        margin-top: 12px;
+        padding: 12px 16px;
+        color: #0d101b;
+        background: #ffd166;
+        border-radius: 8px;
+        text-decoration: none;
+        font-weight: 600;
+        box-shadow: 0 6px 18px rgba(255, 209, 102, 0.35);
+      }
+
+      code {
+        background: rgba(255, 255, 255, 0.08);
+        padding: 2px 6px;
+        border-radius: 6px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Pixie Playground</h1>
+      <p>
+        Start a local server from the repository root, then pick an experiment to try.
+        If you saw a <strong>Not Found</strong> page earlier, this index was missing—running
+        a static server now will serve this page and the prototype below.
+      </p>
+      <p>
+        Quick start:
+        <code>python -m http.server 8000</code> &rarr; open
+        <code>http://localhost:8000/</code>
+      </p>
+      <a class="button" href="/games/starlight-picker/">Launch Starlight Picker</a>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a root playground landing page that links to the Starlight Picker prototype
- update the README to point users to the new launcher and correct startup steps

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d2f1edcb483208017583462fc8b72)